### PR TITLE
修复报表获取翻页bug，优化获取全部报表

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor
+.idea

--- a/src/Report/Ad.php
+++ b/src/Report/Ad.php
@@ -79,7 +79,33 @@ class Ad extends ArrayCollection
         return $res;
     }
 
+    /**
+     * 使用生成器的方式获取,不需要一次性获取全部，避免内存过大
+     *
+     * @param int $pageSize
+     * @return \Generator
+     */
+    public function allReportIterator($pageSize = 100) {
+        $this->set('page_size', $pageSize);
 
+        $page = $this->get('page') ?: 1;
+
+        $totalPage = 1;
+
+        do {
+            try {
+                $report = $this->report()->get('data');
+
+                $totalPage = $report['page_info']['total_page'];
+
+                yield $report['list'];
+            } catch (\Exception $e) {
+                // 什么都不做，下一页
+            }
+
+            $this->set('page', ++$page);
+        } while ($page <= $totalPage);
+    }
 
     /**
      * 获取向头条请求的参数

--- a/src/Report/Ad.php
+++ b/src/Report/Ad.php
@@ -120,8 +120,8 @@ class Ad extends ArrayCollection
         $defaults = [
             'start_date' => date('Y-m-d'),
             'end_date' => date('Y-m-d'),
-            'page' => 1,
-            'page_size' => 100,
+            'page' => $this->get('page') ?: 1,
+            'page_size' => $this->get('page_size') ?: 100,
             'time_granularity' => $this->time_granularity ?: current($this->time_granularitys),
             'group_by' => $this->group_fields ?: [current($this->group_by)],
             'filtering' => [],

--- a/src/Report/Creative.php
+++ b/src/Report/Creative.php
@@ -57,6 +57,34 @@ class Creative extends ArrayCollection
     }
 
     /**
+     * 使用生成器的方式获取,不需要一次性获取全部，避免内存过大
+     *
+     * @param int $pageSize
+     * @return \Generator
+     */
+    public function allReportIterator($pageSize = 100) {
+        $this->set('page_size', $pageSize);
+
+        $page = $this->get('page') ?: 1;
+
+        $totalPage = 1;
+
+        do {
+            try {
+                $report = $this->report()->get('data');
+
+                $totalPage = $report['page_info']['total_page'];
+
+                yield $report['list'];
+            } catch (\Exception $e) {
+                // 什么都不做，下一页
+            }
+
+            $this->set('page', ++$page);
+        } while ($page <= $totalPage);
+    }
+
+    /**
      * 获取向头条请求的参数
      * @return array
      */

--- a/src/Report/Creative.php
+++ b/src/Report/Creative.php
@@ -95,8 +95,8 @@ class Creative extends ArrayCollection
         $defaults = [
             'start_date' => date('Y-m-d'),
             'end_date' => date('Y-m-d'),
-            'page' => 1,
-            'page_size' => 100,
+            'page' => $this->get('page') ?: 1,
+            'page_size' => $this->get('page_size') ?: 100,
             'time_granularity' => $this->time_granularity ?: current($this->time_granularitys),
             'group_by' => $this->group_fields ?: [current($this->group_by)],
             'filtering' => [],


### PR DESCRIPTION
一次性获取全部报表，可能会消耗比较多内存。可以使用生成器的方式，分批获取。对外是不可见的，直接当数循环即可。